### PR TITLE
fix(packages): upgrade packages and deep-extend due to nsp vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,22 +28,22 @@
   "homepage": "https://github.com/emartech/boar-koa-server",
   "dependencies": {
     "app-root-path": "2.0.1",
-    "deep-extend": "0.5.0",
+    "deep-extend": "0.6.0",
     "kcors": "2.2.1",
-    "koa-bodyparser": "4.2.0",
-    "koa-helmet": "3.2.0",
+    "koa-bodyparser": "4.2.1",
+    "koa-helmet": "4.0.0",
     "koa-methodoverride": "2.0.0",
     "koa-requestid": "2.0.1",
-    "koa-router": "7.2.1",
+    "koa-router": "7.4.0",
     "koa-ssl": "2.0.0"
   },
   "devDependencies": {
     "chai": "4.1.2",
-    "eslint": "4.6.1",
-    "eslint-config-emarsys": "4.0.0",
-    "mocha": "3.5.1",
-    "nsp": "2.8.0",
+    "eslint": "4.19.1",
+    "eslint-config-emarsys": "5.1.0",
+    "mocha": "5.2.0",
+    "nsp": "3.2.1",
     "semantic-release": "7.0.2",
-    "sinon": "3.2.1"
+    "sinon": "6.0.0"
   }
 }


### PR DESCRIPTION
Deep-extend had a [Prototype Pollution vulnerability](https://nodesecurity.io/advisories/612), this pull request bump its version where it is fixed.
Upgraded other outdated packages.