### PR TITLE
feat(security-middlewares): add possibility to include Referrer-Policy header from middlewares

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,3 @@
-package-lock=false
+package-lock=true
 save-exact=true
 save=true

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Provides middlewares for setting up various security related HTTP headers.
 | ↳hsts | `Object` | [More info.](https://github.com/helmetjs/hsts) Learn more: [OWASP HSTS page](https://www.owasp.org/index.php/HTTP_Strict_Transport_Security) |
 | ↳useXssFilter | `Boolean` | If `true`, [x-xss-protection](https://github.com/helmetjs/x-xss-protection) middleware will be included. Default: `true` |
 | ↳useNoSniff | `Boolean` |  If `true`, [dont-sniff-mimetype](https://github.com/helmetjs/dont-sniff-mimetype) middleware will be included. Default: `true` |
+| ↳referrerPolicy| `Boolean,Object` | If`{ policy: 'same-origin'}`, [referrer-policy](https://github.com/helmetjs/referrer-policy) middleware will be included. Default `false` |
 
 ``` javascript
   app.addSecurityMiddlewares(options);
@@ -114,7 +115,8 @@ Provides middlewares for setting up various security related HTTP headers.
       preload: false
     },
     useXssFilter: true,
-    useNoSniff: true
+    useNoSniff: true,
+    referrerPolicy: false
   }
 ```
 

--- a/lib/security-middleware-factory/index.js
+++ b/lib/security-middleware-factory/index.js
@@ -28,7 +28,8 @@ class SecurityMiddlewareFactory {
         preload: false
       },
       useXssFilter: true,
-      useNoSniff: true
+      useNoSniff: true,
+      referrerPolicy: false
     };
   }
 
@@ -48,6 +49,10 @@ class SecurityMiddlewareFactory {
     return helmet.noSniff();
   }
 
+  getReferrerPolicyMiddleware() {
+    return helmet.referrerPolicy(this._config.referrerPolicy);
+  }
+
   getMiddlewares() {
     let middlewares = [
       this.getCspMiddleware(),
@@ -60,6 +65,10 @@ class SecurityMiddlewareFactory {
 
     if (this._config.useNoSniff) {
       middlewares.push(this.getNoSniffMiddleware());
+    }
+
+    if (this._config.referrerPolicy) {
+      middlewares.push(this.getReferrerPolicyMiddleware());
     }
 
     return middlewares;

--- a/lib/security-middleware-factory/index.spec.js
+++ b/lib/security-middleware-factory/index.spec.js
@@ -159,7 +159,7 @@ describe('Security Middleware Factory', function() {
       expect(securityMiddlewareFactory.getMiddlewares()).to.contains('referrerPolicy');
     });
 
-    it('should not contain referrer policy if no option provided for it', function () {
+    it('should not contain referrer policy if no option provided for it', function() {
       const securityMiddlewareFactory = new SecurityMiddlewareFactory();
       expect(securityMiddlewareFactory.getMiddlewares()).to.not.contains('referrerPolicy');
     });

--- a/lib/security-middleware-factory/index.spec.js
+++ b/lib/security-middleware-factory/index.spec.js
@@ -10,7 +10,7 @@ describe('Security Middleware Factory', function() {
   let sandbox;
 
   beforeEach(function() {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
 
     sandbox.spy(helmet, 'contentSecurityPolicy');
     sandbox.spy(helmet, 'hsts');
@@ -92,6 +92,42 @@ describe('Security Middleware Factory', function() {
   });
 
 
+  describe('#getReferrerPolicyMiddleware', function() {
+    const createContextStub = () => {
+      return {
+        request: {},
+        req: {},
+        res: {
+          setHeader: sinon.stub()
+        }
+      };
+    };
+
+    it('should set "no-referrer" value on header by default', async function() {
+      const securityMiddlewareFactory = new SecurityMiddlewareFactory();
+      const middleware = securityMiddlewareFactory.getReferrerPolicyMiddleware();
+
+      const contextStub = createContextStub();
+
+      await middleware(contextStub);
+
+      expect(contextStub.res.setHeader.calledWith('Referrer-Policy', 'no-referrer')).to.be.ok;
+    });
+
+    it('should set the header for the given policy', async function() {
+      const policy = 'same-origin';
+      const securityMiddlewareFactory = new SecurityMiddlewareFactory({ referrerPolicy: { policy } });
+      const middleware = securityMiddlewareFactory.getReferrerPolicyMiddleware();
+
+      const contextStub = createContextStub();
+
+      await middleware(contextStub);
+
+      expect(contextStub.res.setHeader.calledWith('Referrer-Policy', policy)).to.be.ok;
+    });
+  });
+
+
   describe('#getMiddlewares', function() {
 
     beforeEach(function() {
@@ -101,6 +137,7 @@ describe('Security Middleware Factory', function() {
       sandbox.stub(helmet, 'hsts').returns('hsts');
       sandbox.stub(helmet, 'xssFilter').returns('xssFilter');
       sandbox.stub(helmet, 'noSniff').returns('noSniff');
+      sandbox.stub(helmet, 'referrerPolicy').returns('referrerPolicy');
     });
 
 
@@ -112,12 +149,23 @@ describe('Security Middleware Factory', function() {
           'contentSecurityPolicy', 'hsts', 'xssFilter', 'noSniff'
         ]);
       });
+    });
 
+    it('should contain referrer policy only if provided a good policy', function() {
+      const securityMiddlewareFactory = new SecurityMiddlewareFactory({
+        referrerPolicy: { policy: 'same-origin' }
+      });
+
+      expect(securityMiddlewareFactory.getMiddlewares()).to.contains('referrerPolicy');
+    });
+
+    it('should not contain referrer policy if no option provided for it', function () {
+      const securityMiddlewareFactory = new SecurityMiddlewareFactory();
+      expect(securityMiddlewareFactory.getMiddlewares()).to.not.contains('referrerPolicy');
     });
 
 
     describe('with middlewares turned off', function() {
-
       it('should not return the xssFilter middleware when it is disabled', function() {
         expect(new SecurityMiddlewareFactory({ useXssFilter: false }).getMiddlewares()).to.not.contains('xssFilter');
       });

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "code-style": "eslint '**/*.js'",
     "test-run": "mocha ./lib --recursive",
-    "test": "npm run test-run && nsp check && npm run code-style",
+    "test": "npm run test-run && npm audit && npm run code-style",
     "semantic-release": "CI=true semantic-release"
   },
   "repository": {
@@ -13,7 +13,7 @@
     "url": "git+https://github.com/emartech/boar-koa-server.git"
   },
   "engines": {
-    "node": "8"
+    "node": "10"
   },
   "author": "Emarsys",
   "license": "MIT",
@@ -37,7 +37,6 @@
     "eslint": "4.19.1",
     "eslint-config-emarsys": "5.1.0",
     "mocha": "5.2.0",
-    "nsp": "3.2.1",
     "semantic-release": "15.5.5",
     "sinon": "6.0.0"
   }


### PR DESCRIPTION
This PR makes it possible to setup Referrer-Policy header through the security middlewares via config.
The header is excluded by default to not break anything.
Upgraded the engine and removed the nsp dependency in favour of npm audit, because it is no longer supported.
